### PR TITLE
Telnet target aborting

### DIFF
--- a/TelnetTarget/TelnetTarget/NewTargetWindow.xaml
+++ b/TelnetTarget/TelnetTarget/NewTargetWindow.xaml
@@ -8,10 +8,11 @@
              SizeToContent="WidthAndHeight"
             Title="New telnet connection...">
     <Window.Resources>
-        <local:TelnetParameters x:Key="sampleParameters" Host="linuxbox" Port="1234" UserName="user" Password="pass"/>
+        <local:TelnetParameters x:Key="sampleParameters" Host="linuxbox" Port="1234" UserName="user" Password="pass" Timeout="3000"/>
     </Window.Resources>
     <Grid d:DataContext="{StaticResource sampleParameters}" Margin="5">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -35,7 +36,10 @@
         <TextBlock Text="Password: " Grid.Column="0" Grid.Row="3"/>
         <TextBox Text="{Binding Password}" Grid.Column="1" Grid.Row="3" MinWidth="100"/>
 
-        <StackPanel Orientation="Horizontal" Grid.Row="4" Grid.ColumnSpan="2" Margin="0 5 0 0">
+        <TextBlock Text="Timeout: " Grid.Column="0" Grid.Row="4"/>
+        <TextBox Text="{Binding Timeout}" Grid.Column="1" Grid.Row="4" MinWidth="100"/>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" Margin="0 5 0 0">
             <Button MinWidth="80" Margin="5" Click="OK_Click">
                 <TextBlock Text="OK" Margin="5 0 5 0"/>
             </Button>

--- a/TelnetTarget/TelnetTarget/NewTargetWindow.xaml
+++ b/TelnetTarget/TelnetTarget/NewTargetWindow.xaml
@@ -8,7 +8,7 @@
              SizeToContent="WidthAndHeight"
             Title="New telnet connection...">
     <Window.Resources>
-        <local:TelnetParameters x:Key="sampleParameters" Host="linuxbox" Port="1234" UserName="user" Password="pass" Timeout="3000"/>
+        <local:TelnetParameters x:Key="sampleParameters" Host="linuxbox" Port="1234" UserName="user" Password="pass" Timeout="10000"/>
     </Window.Resources>
     <Grid d:DataContext="{StaticResource sampleParameters}" Margin="5">
         <Grid.RowDefinitions>

--- a/TelnetTarget/TelnetTarget/TelnetConnection.cs
+++ b/TelnetTarget/TelnetTarget/TelnetConnection.cs
@@ -156,6 +156,10 @@ namespace TelnetTarget
                 throw new Exception("Failed to login");
         }
 
+        public void SetReceiveTimeout(int timeout) {
+            _Client.ReceiveTimeout = timeout;
+        }
+
         public void Dispose()
         {
             try

--- a/TelnetTarget/TelnetTarget/TelnetConnection.cs
+++ b/TelnetTarget/TelnetTarget/TelnetConnection.cs
@@ -154,13 +154,6 @@ namespace TelnetTarget
             }
             if (!text.Contains(marker))
                 throw new Exception("Failed to login");
-
-            _Client.ReceiveTimeout = 0;
-        }
-
-        public void SetTimeout(int timeout)
-        {
-            _Client.ReceiveTimeout = timeout;
         }
 
         public void Dispose()

--- a/TelnetTarget/TelnetTarget/TelnetConnection.cs
+++ b/TelnetTarget/TelnetTarget/TelnetConnection.cs
@@ -141,8 +141,18 @@ namespace TelnetTarget
 
         public TelnetConnection(TelnetParameters parameters)
         {
-            _Client = new TcpClient(parameters.Host, parameters.Port);
-            _Client.ReceiveTimeout = 10000;
+            _Client = new TcpClient();
+            _Client.ReceiveTimeout = parameters.Timeout;
+            _Client.SendTimeout = parameters.Timeout;
+
+            var result = _Client.BeginConnect(parameters.Host, parameters.Port, null, null);
+            bool success = result.AsyncWaitHandle.WaitOne(parameters.Timeout, true);
+            if(success) {
+                _Client.EndConnect(result);
+            } else {
+                _Client.Close();
+                throw new SocketException(10060); // Connection timed out.
+            }
 
             ReadTextUntilEventAndHandleTelnetCommands(s => s.EndsWith("login:", StringComparison.InvariantCultureIgnoreCase));
             WriteText(parameters.UserName + "\r\n");
@@ -161,7 +171,8 @@ namespace TelnetTarget
                 throw new Exception("Failed to login");
         }
 
-        public void SetReceiveTimeout(int timeout) {
+        public void SetReceiveTimeout(int timeout)
+        {
             _Client.ReceiveTimeout = timeout;
         }
 

--- a/TelnetTarget/TelnetTarget/TelnetConnection.cs
+++ b/TelnetTarget/TelnetTarget/TelnetConnection.cs
@@ -151,7 +151,7 @@ namespace TelnetTarget
                 _Client.EndConnect(result);
             } else {
                 _Client.Close();
-                throw new SocketException(10060); // Connection timed out.
+                throw new SocketException((int)SocketError.TimedOut);
             }
 
             ReadTextUntilEventAndHandleTelnetCommands(s => s.EndsWith("login:", StringComparison.InvariantCultureIgnoreCase));

--- a/TelnetTarget/TelnetTarget/TelnetTarget.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTarget.cs
@@ -78,9 +78,7 @@ namespace TelnetTarget
                     else
                     {
                         //Read and discard everything before the start marker. These lines to not belong to our command.
-                        _Connection.SetTimeout(1000);
                         string text = _Connection.ReadTextUntilEventAndHandleTelnetCommands(s => s.EndsWith(_BeginMarker + "\r\n"));
-                        _Connection.SetTimeout(0);
                     }
 
                     //We don't know for sure where the command output ends and our end marker starts. Hence we have to guess it and immediately output everything that does not
@@ -211,10 +209,8 @@ namespace TelnetTarget
             string marker = $"com.sysprogs.tty:{Guid.NewGuid().ToString()}:";
             conn.WriteText($"echo {marker} ; tty ; sleep {int.MaxValue}\r\n");
 
-            conn.SetTimeout(2000);
             string prefix = conn.ReadTextUntilEventAndHandleTelnetCommands(s => s.EndsWith("\r\n" + marker + "\r\n"));
             string tty = conn.ReadTextUntilEventAndHandleTelnetCommands(s => s.EndsWith("\r\n")).TrimEnd();
-            conn.SetTimeout(0);
 
             return new TelnetConsole(this, conn, tty);
         }

--- a/TelnetTarget/TelnetTarget/TelnetTarget.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTarget.cs
@@ -205,7 +205,10 @@ namespace TelnetTarget
             if (!string.IsNullOrEmpty(directory))
                 commandLine = string.Format("cd \"{0}\" && {1}", directory, commandLine);
 
-            return new TelnetCommand(this, ProvideConnection(), commandLine);
+            var connection = ProvideConnection();
+            if ((flags & CommandFlags.EnableTerminalEmulation) != CommandFlags.None)
+                connection.SetReceiveTimeout(0);
+            return new TelnetCommand(this, connection, commandLine);
         }
 
         public IRemoteConsole CreateVirtualConsole()

--- a/TelnetTarget/TelnetTarget/TelnetTarget.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTarget.cs
@@ -297,7 +297,6 @@ namespace TelnetTarget
                     using (var stream = new MemoryStream())
                     {
                         file.CopyTo(stream, tempBuffer, file.Size);
-                        cmd.SendInput(Convert.ToBase64String(stream.ToArray(), Base64FormattingOptions.InsertLineBreaks));
                         var base64Data = Convert.ToBase64String(stream.ToArray(), Base64FormattingOptions.InsertLineBreaks);
                         using(var reader = new StringReader(base64Data)) 
                         {

--- a/TelnetTarget/TelnetTarget/TelnetTarget.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTarget.cs
@@ -296,6 +296,14 @@ namespace TelnetTarget
                     {
                         file.CopyTo(stream, tempBuffer, file.Size);
                         cmd.SendInput(Convert.ToBase64String(stream.ToArray(), Base64FormattingOptions.InsertLineBreaks));
+                        var base64Data = Convert.ToBase64String(stream.ToArray(), Base64FormattingOptions.InsertLineBreaks);
+                        using(var reader = new StringReader(base64Data)) 
+                        {
+                            int readed;
+                            var dataChunk = new char[65 * 1024];
+                            while((readed = reader.Read(dataChunk, 0, dataChunk.Length)) > 0) 
+                                cmd.SendInput(new string(dataChunk, 0, readed));
+                        }
                     }
 
                     cmd.SendInput("\r\n\x04");

--- a/TelnetTarget/TelnetTarget/TelnetTarget.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTarget.cs
@@ -302,7 +302,7 @@ namespace TelnetTarget
                         {
                             int readed;
                             var dataChunk = new char[65 * 1024];
-                            while((readed = reader.Read(dataChunk, 0, dataChunk.Length)) > 0) 
+                            while((readed = reader.Read(dataChunk, 0, dataChunk.Length)) > 0 && !done.WaitOne(0)) 
                                 cmd.SendInput(new string(dataChunk, 0, readed));
                         }
                     }

--- a/TelnetTarget/TelnetTarget/TelnetTargetFactory.cs
+++ b/TelnetTarget/TelnetTarget/TelnetTargetFactory.cs
@@ -14,6 +14,7 @@ namespace TelnetTarget
         public int Port { get; set; } = 23;
         public string UserName { get; set; }
         public string Password { get; set; }
+        public int Timeout { get; set; } = 10000;
     }
 
     /// <summary>


### PR DESCRIPTION
When working with telnet-based target, very large inconveniences are caused by connection bindings and correspondingly freezes of Visual Studio, sometimes awaiting periods reach several minutes.

I modified the TelnetTarget code:
- added a Timeout option in the connection settings window.
Removed places with no timeout:
```C#
		_Connection.SetTimeout(0);
		_Client.ReceiveTimeout = 0;
```
- set TcpClient.SendTimeout value from connection parameters.
- added timeout possibility to the TcpClient connecting.

To avoid interrupting the transfer of large files due to a timeout, the file transfer has been converted to a fragmented transfer, with 64K chunks.